### PR TITLE
Testcontainer를 이용한 통합 테스트 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 
     // 런타임에 클래스 기반 spock mock을 만들기 위해서 필요
     testImplementation('net.bytebuddy:byte-buddy:1.12.20')
+
+    // testcontainers
+    testImplementation('org.testcontainers:spock:1.17.1')
+    testImplementation('org.testcontainers:mariadb:1.17.1')
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.2'
     id 'io.spring.dependency-management' version '1.1.0'
+    id 'groovy'
 }
 
 group = 'dev.be'
@@ -30,6 +31,13 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // spock
+    testImplementation('org.spockframework:spock-core:2.4-M1-groovy-4.0')
+    testImplementation('org.spockframework:spock-spring:2.4-M1-groovy-4.0')
+
+    // 런타임에 클래스 기반 spock mock을 만들기 위해서 필요
+    testImplementation('net.bytebuddy:byte-buddy:1.12.20')
 }
 
 tasks.named('test') {

--- a/src/test/groovy/dev/be/pharmacyrecommendation/AbstractIntegrationContainerBaseTest.groovy
+++ b/src/test/groovy/dev/be/pharmacyrecommendation/AbstractIntegrationContainerBaseTest.groovy
@@ -1,0 +1,19 @@
+package dev.be.pharmacyrecommendation
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.testcontainers.containers.GenericContainer
+
+@SpringBootTest
+abstract class AbstractIntegrationContainerBaseTest {
+    static final GenericContainer MY_REDIS_CONTAINER
+
+    static {
+        MY_REDIS_CONTAINER = new GenericContainer<>("redis:6")
+                .withExposedPorts(6379)
+
+        MY_REDIS_CONTAINER.start()
+
+        System.setProperty("spring.redis.host", MY_REDIS_CONTAINER.getHost())
+        System.setProperty("spring.redis.port", MY_REDIS_CONTAINER.getMappedPort(6379).toString())
+    }
+}

--- a/src/test/groovy/dev/be/pharmacyrecommendation/api/service/KakaoUriBuilderServiceTest.groovy
+++ b/src/test/groovy/dev/be/pharmacyrecommendation/api/service/KakaoUriBuilderServiceTest.groovy
@@ -1,0 +1,31 @@
+package dev.be.pharmacyrecommendation.api.service
+
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class KakaoUriBuilderServiceTest extends Specification {
+
+    private KakaoUriBuilderService kakaoUriBuilderService
+
+
+    def setup(){
+        // run before every feature method
+        kakaoUriBuilderService = new KakaoUriBuilderService()
+    }
+
+    def "buildUriByAddressSearch - 한글 파라미터의 경우 정상적으로 인코딩"(){
+        given:
+        String address = "서울 성북구"
+        def charset = StandardCharsets.UTF_8
+
+        when:
+        def uri = kakaoUriBuilderService.buildUriByAddressSearch(address)
+        def decode = URLDecoder.decode(uri.toString(), charset)
+
+        then:
+        println(uri)
+        decode == "https://dapi.kakao.com/v2/local/search/address.json?query=서울 성북구"
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mariadb:10:///
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+
+kakao:
+  rest:
+    api:
+      key: ${KAKAO_REST_API_KEY}


### PR DESCRIPTION
테스트를 위해
-  Spock, TestContainers 에 대한 의존성 추가
- 개발/ 운영 환경과 분리하기 위해서 test 디렉토리 내에 `application.yml` 생성
- 각 테스트 코드의 외부 요인에 대한 멱등성을 위해 `AbstractIntegrationContainerBaseTest` 생성

This closes #18 