### PR TITLE
카카오 키워드 장소 검색 api 적용

### DIFF
--- a/src/main/java/dev/be/pharmacyrecommendation/api/dto/DocumentDto.java
+++ b/src/main/java/dev/be/pharmacyrecommendation/api/dto/DocumentDto.java
@@ -12,8 +12,12 @@ import lombok.NoArgsConstructor;
 @Builder
 public class DocumentDto {
 
+    @JsonProperty("place_name") private String placeName;
     @JsonProperty("address_name") private String addressName;
+
     @JsonProperty("y") private double latitude;
     @JsonProperty("x") private double longitude;
+
+    @JsonProperty("distance") private double distance;
 
 }

--- a/src/main/java/dev/be/pharmacyrecommendation/api/service/KakaoCategorySearchService.java
+++ b/src/main/java/dev/be/pharmacyrecommendation/api/service/KakaoCategorySearchService.java
@@ -1,0 +1,37 @@
+package dev.be.pharmacyrecommendation.api.service;
+
+import dev.be.pharmacyrecommendation.api.dto.KakaoApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoCategorySearchService {
+
+    private final KakaoUriBuilderService kakaoUriBuilderService;
+    private final RestTemplate restTemplate;
+
+    private static final String PHARMACY_CATEGORY = "PM9";
+
+    @Value("${kakao.rest.api.key}") private String kakaoRestApiKey;
+
+    public KakaoApiResponseDto requestPharmacyCategorySearch(double latitude, double longitude, double radius) {
+        URI uri = kakaoUriBuilderService.buildUriByCategorySearch(latitude, longitude, radius, PHARMACY_CATEGORY);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoRestApiKey);
+        HttpEntity httpEntity = new HttpEntity<>(headers);
+
+        return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoApiResponseDto.class).getBody();
+    }
+
+}

--- a/src/main/java/dev/be/pharmacyrecommendation/api/service/KakaoUriBuilderService.java
+++ b/src/main/java/dev/be/pharmacyrecommendation/api/service/KakaoUriBuilderService.java
@@ -11,6 +11,7 @@ import java.net.URI;
 public class KakaoUriBuilderService {
 
     private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+    private static final String KAKAO_LOCAL_CATEGORY_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/category.json";
 
     public URI buildUriByAddressSearch(String address) {
         UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_SEARCH_ADDRESS_URL);
@@ -19,6 +20,25 @@ public class KakaoUriBuilderService {
         URI uri = builder.build().encode().toUri();
 
         log.info("[ KakaoUriBuilderService buildUriByAddressSearch ] address: {}, uri: {}", address, uri);
+
+        return uri;
+    }
+
+    public URI buildUriByCategorySearch(double latitude, double longitude, double radius, String category) {
+        double meterRadius = radius * 1000;
+
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_CATEGORY_SEARCH_URL);
+
+        URI uri = uriBuilder.queryParam("category_group_code", category)
+                .queryParam("x", longitude)
+                .queryParam("y", latitude)
+                .queryParam("radius", meterRadius)
+                .queryParam("sort", "distance")
+                .build()
+                .encode()
+                .toUri();
+
+        log.info("[KakaoUriBuilderService buildUriByCategorySearch] uri : {}", uri);
 
         return uri;
     }

--- a/src/main/java/dev/be/pharmacyrecommendation/pharmacy/service/PharmacyRecommendationService.java
+++ b/src/main/java/dev/be/pharmacyrecommendation/pharmacy/service/PharmacyRecommendationService.java
@@ -34,7 +34,8 @@ public class PharmacyRecommendationService {
 
         DocumentDto documentDto = kakaoApiResponseDto.getDocumentList().get(0);
 
-        List<Direction> directionList = directionService.buildDirectionList(documentDto);
+//        List<Direction> directionList = directionService.buildDirectionList(documentDto);
+        List<Direction> directionList = directionService.buildDirectionListByCategoryApi(documentDto);
 
         directionService.saveAll(directionList);
     }

--- a/src/test/groovy/dev/be/pharmacyrecommendation/api/service/KakaoCategorySearchServiceTest.groovy
+++ b/src/test/groovy/dev/be/pharmacyrecommendation/api/service/KakaoCategorySearchServiceTest.groovy
@@ -1,0 +1,37 @@
+package dev.be.pharmacyrecommendation.api.service
+
+import dev.be.pharmacyrecommendation.AbstractIntegrationContainerBaseTest
+import dev.be.pharmacyrecommendation.api.dto.KakaoApiResponseDto
+import org.springframework.beans.factory.annotation.Autowired
+
+import java.util.stream.Collectors
+
+class KakaoCategorySearchServiceTest extends AbstractIntegrationContainerBaseTest{
+
+    @Autowired private KakaoCategorySearchService kakaoCategorySearchService
+
+    def "requestCategorySearch sort by distance"(){
+        given:
+        double x = 127.037033003036 // longitude
+        double y = 37.5960650456809 // latitude
+        double radius = 10.0 // km
+
+        when:
+        def result = kakaoCategorySearchService.requestPharmacyCategorySearch(x, y, radius)
+
+        def inputList = result.getDocumentList().stream()
+                .map(t -> t.getDistance())
+                .collect(Collectors.toList())
+
+        def outputList = inputList.stream()
+                .sorted()
+                .collect(Collectors.toList())
+
+        then:
+        inputList == outputList
+        inputList.size() == outputList.size()
+        assert result.getDocumentList().every() {
+            it.getDistance() <= radius * 1000
+        }
+    }
+}


### PR DESCRIPTION
카카오 API 를 이용하여 
키워드 검색으로 정해진 거리내의 약국을 찾는 기능을 추가

This closes #36 